### PR TITLE
Support for multiple contributors and/or PRs in changelog

### DIFF
--- a/.github/tweak_changelogs.sh
+++ b/.github/tweak_changelogs.sh
@@ -3,9 +3,7 @@
 RELEASE_VERSION="$1"
 
 # Remove all CR characters from all changelog files
-sed -i 's/\r//g' temp_change.md
-sed -i 's/\r//g' CHANGELOG.md
-sed -i 's/\r//g' changelog.txt
+sed -i 's/\r//g' temp_change.md CHANGELOG.md changelog.txt
 
 # Delete until and including the first line containing "<!-- Release notes generated"
 sed -i '1,/^<!-- Release notes generated/d' temp_change.md
@@ -15,9 +13,16 @@ sed -i '1h;1d;$!H;$!d;G' temp_change.md
 sed -i -re 's/\*\*Full Changelog\*\*: (.*)/\[Full Changelog\]\(\1\)\n/' temp_change.md
 # Delete everything from "## New Contributors" line to the end of file
 sed -i '/## New Contributors/,$d' temp_change.md
-# Convert GitHub changelog entries from "* description by @username in pull/URL/number"
-# to "- description [#number](pull/URL/number) ([username](https://github.com/username))" format
-sed -i -re 's/^\*(.*)\sby\s@(.*)\sin\s(.*\/pull\/)(.*)/-\1 [\\#\4](\3\4) ([\2](https:\/\/github.com\/\2))/' temp_change.md;
+# Convert GitHub changelog entries to markdown format
+# "* description by (@username1, @username2) in #1310, #1311" → "- description #1310, #1311 (@username1, @username2)"
+sed -i -re 's/^\*\s(.*)\sby\s\(?(@[^)]*[^) ])\)?\s+in\s+(.*)/- \1 \3 (\2)/' temp_change.md
+# Convert @usernames to github links
+# "(@username1, @username2)" → "([username1](https://github.com/username1), [username2](https://github.com/username2))"
+sed -i -re 's/@([a-zA-Z0-9_-]+)/[\1](https:\/\/github.com\/\1)/g' temp_change.md
+# Convert full PR URLs to linked format  
+# "https://github.com/repo/pull/1310" → "[\#1310](https://github.com/repo/pull/1310)"
+sed -i -re 's/(https:\/\/[^) ]*\/pull\/([0-9]+))/[\\#\2](\1)/g' temp_change.md
+
 # Username substitutions for preferred display names
 sed -i 's/\[Quotae/\[Quote_a/' temp_change.md
 sed -i 's/\[learn2draw/\[Lexy/' temp_change.md
@@ -31,14 +36,16 @@ cat CHANGELOG.md | sed '1d' >> temp_change.md
 # Create new CHANGELOG.md with header containing version and date, followed by processed changes
 printf "# Changelog\n\n## [$RELEASE_VERSION](https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/tree/$RELEASE_VERSION) ($(date +'%Y/%m/%d'))\n\n" | cat - temp_change.md > CHANGELOG.md
 # Convert changelog entries from markdown link format to simplified "* description (username)" format
-sed -i -re 's/^- (.*) \[.*\) \(\[(.*)\]\(.*/* \1 (\2)/' changelog_temp.txt
+# First remove all PR links
+sed -i -re 's/ ?\(?\[\\#[0-9]+\]\([^)]*\),? ?\)?//g' changelog_temp.txt
+# Remove markdown link formatting from usernames in parentheses
+sed -i -re 's/\[([^]]*)\]\(https:\/\/github\.com\/[^)]*\)/\1/g' changelog_temp.txt
 # Create new changelog format: add version header, remove lines 2-3, format section headers, remove ## headers with following line, prepend to existing changelog
 echo "VERSION[${RELEASE_VERSION#v}][$(date +'%Y/%m/%d')]" | cat - changelog_temp.txt | sed '2,3d' | sed -re 's/^### (.*)/\n--- \1 ---/' | sed -e '/^##.*/,+1 d' | cat - changelog.txt > changelog_new.txt
 mv changelog_new.txt changelog.txt
 
 # Normalize line endings to CRLF for all output files to ensure consistent checksums with Windows
-sed 's/\r*$/\r/' CHANGELOG.md > CHANGELOG_normalized.md && mv CHANGELOG_normalized.md CHANGELOG.md
-sed 's/\r*$/\r/' changelog.txt > changelog_normalized.txt && mv changelog_normalized.txt changelog.txt
+sed -i 's/\r*$/\r/' CHANGELOG.md changelog.txt
 
 # Clean up temporary files
 rm temp_change.md


### PR DESCRIPTION
### Description of the problem being solved:
This simplifies the handling of the `\r` character by removing them all at the beginning and adding them back at the end (so that we don't have to care about them in the rest of the process).

It also adds the support of multiple PRs and contributors (when generating a release with a provided releaseNoteUrl).

For example, with `* Handle multiple PRs and contributors in changelog generation + Simplify CR handling by (@Musholic, @LocalIdentity) in (https://github.com/Musholic/PathOfBuilding-PoE2/pull/12 , https://github.com/Musholic/PathOfBuilding-PoE2/pull/11)` in the draft release, it produces TODO