### PR TITLE
Make sure it uses the latest available tag for generating beta changelog

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -28,7 +28,9 @@ jobs:
                   gh release delete beta --yes
                 fi
                 # Create new beta draft release with generated notes
-                gh release create beta --title "Beta Release" --draft --generate-notes
+                # Make sure the latest tag is correct, even if the current commit is already tagged
+                LATEST_TAG=$(git describe --tags --abbrev=0)
+                gh release create beta --title "Beta Release" --draft --generate-notes --notes-start-tag "$LATEST_TAG"
                 gh release view beta > temp_change.md
             - name: Tweak changelogs
               id: tweak-changelogs


### PR DESCRIPTION
### Description of the problem being solved:
Fix the changelog generation for the beta release when it's done after a release, on an already tagged commit. 

Without this fix, the draft release may use an older tag to generate the changelog