### PR TITLE
Automate release workflow

### DIFF
--- a/.github/tweak_changelogs.sh
+++ b/.github/tweak_changelogs.sh
@@ -2,8 +2,13 @@
 
 RELEASE_VERSION="$1"
 
-# Delete until and including the first line containing "<!-- Release notes generated"
-sed -i '1,/^<!-- Release notes generated/d' temp_change.md
+if grep -q "<!-- Release notes generated" temp_change.md; then
+    # Delete until and including the first line containing "<!-- Release notes generated"
+    sed -i '1,/^<!-- Release notes generated/d' temp_change.md
+else
+    # Otherwise, delete until and including the first line containing "--" (The release metadata)
+    sed -i '1,/--/d' temp_change.md
+fi
 
 # Check if there is more than one non-empty line (the full changelog line) before we continue
 if [ $(grep -c '^[[:space:]]*[^[:space:]]' temp_change.md) -le 1 ]; then
@@ -43,13 +48,17 @@ cp temp_change.md changelog_temp.txt
 cat CHANGELOG.md | sed '1d' >> temp_change.md
 # Create new CHANGELOG.md with header containing version and date, followed by processed changes
 printf "# Changelog\n\n## [$RELEASE_VERSION](https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/tree/$RELEASE_VERSION) ($(date +'%Y/%m/%d'))\n\n" | cat - temp_change.md > CHANGELOG.md
+
+# Delete until and including the line containing "## What's Changed"
+sed -i "1,/## What's Changed/d" changelog_temp.txt
+
 # Convert changelog entries from markdown link format to simplified "* description (username)" format
 # First remove all PR links
 sed -i -re 's/( \()?\[\\#[0-9]+\]\([^)]*\),? ?\)?//g' changelog_temp.txt
 # Remove markdown link formatting from usernames in parentheses
 sed -i -re 's/\[([^]]*)\]\(https:\/\/github\.com\/[^)]*\)/\1/g' changelog_temp.txt
-# Create new changelog format: add version header, remove lines 2-3, format section headers, remove ## headers with following line, prepend to existing changelog
-echo "VERSION[${RELEASE_VERSION#v}][$(date +'%Y/%m/%d')]" | cat - changelog_temp.txt | sed '2,3d' | sed -re 's/^### (.*)/\n--- \1 ---/' | sed -e '/^##.*/,+1 d' | cat - changelog.txt > changelog_new.txt
+# Create new changelog format: add version header, format section headers, prepend to existing changelog
+echo "VERSION[${RELEASE_VERSION#v}][$(date +'%Y/%m/%d')]" | cat - changelog_temp.txt | sed -re 's/^### (.*)/\n--- \1 ---/' | cat - changelog.txt > changelog_new.txt
 mv changelog_new.txt changelog.txt
 
 # Normalize line endings to CRLF for all output files to ensure consistent checksums with Windows

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,0 +1,36 @@
+# These checks are run for PRs preparing a release
+name: Release Check
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      # ready_for_review is needed for the workaround described at https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs
+      - ready_for_review
+    branches:
+      - 'dev'
+    paths:
+      - 'manifest.xml'
+      - 'changelog.txt' # To detect if this is a release PR
+  workflow_dispatch:
+jobs:
+  check_manifest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set line endings
+        run: git config --global core.autocrlf true
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Update manifest
+        run: python3 update_manifest.py --quiet --in-place
+      - name: Check if the generated manifest is different
+        run: git diff --exit-code manifest.xml
+      - name: Check if the manifest version is correct
+        if: startsWith(github.head_ref, 'release-')
+        run: |
+          MANIFEST_VERSION=$(grep -o '<Version number="[^"]*' manifest.xml | sed 's/<Version number="//')
+          BRANCH_VERSION=$(echo ${{ github.head_ref }} | sed 's/release-//')
+          if [ "$MANIFEST_VERSION" != "$BRANCH_VERSION" ]; then
+            echo "Manifest version ($MANIFEST_VERSION) does not match branch version ($BRANCH_VERSION)"
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,15 +14,17 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+            - name: Set line endings
+              run: git config --global core.autocrlf true
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v5
               with:
                 ref: 'dev'
             - name: Generate Release notes
               if: ${{ github.event.inputs.releaseNoteUrl == '' }}
               run: >
                 echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token;
-                gh release view $(basename $(gh release create v${{ github.event.inputs.releaseVersion }} --title "Release ${{ github.event.inputs.releaseVersion }}" --draft --generate-notes)) > temp_change.md
+                gh release view $(basename $(gh release create --target master v${{ github.event.inputs.releaseVersion }} --title "Release ${{ github.event.inputs.releaseVersion }}" --draft --generate-notes)) > temp_change.md
             - name: Use existing Release notes
               if: ${{ github.event.inputs.releaseNoteUrl != '' }}
               run: >
@@ -34,10 +36,16 @@ jobs:
                 sed -i 's/\r$//' .github/tweak_changelogs.sh
                 chmod +x .github/tweak_changelogs.sh
                 .github/tweak_changelogs.sh "v${{ github.event.inputs.releaseVersion }}"
+            - name: Update manifest version
+              run: |
+                sed -ri "s/<Version number=\"([^\"]*)\"/<Version number=\"${{ github.event.inputs.releaseVersion }}\"/g" manifest.xml
+            - name: Update manifest.xml
+              run: python3 update_manifest.py --quiet --in-place
             - name: Create Pull Request
-              uses: peter-evans/create-pull-request@v5
+              uses: peter-evans/create-pull-request@v7
               with:
-                  draft: true
+                  # draft: always-true is needed for the workaround described at https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs
+                  draft: always-true
                   title: Release ${{ github.event.inputs.releaseVersion }}
                   branch: release-${{ github.event.inputs.releaseVersion }}
                   body: |

--- a/.github/workflows/sync-release-to-master.yml
+++ b/.github/workflows/sync-release-to-master.yml
@@ -1,0 +1,29 @@
+name: Sync Release to Master
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - dev
+
+jobs:
+  sync-release-to-master:
+    # Checks that the push to dev was from a pull request whose head branch started with 'release-'.
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Configure bot user
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Merge fast-forward dev into master
+        run: |
+          git merge ${{ github.sha }} --ff-only
+          git push

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on:
     branches: [ dev ]
   pull_request:
     branches: [ dev ]
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
   workflow_dispatch:
 jobs:
   run_tests:


### PR DESCRIPTION
### Description of the problem being solved:
This automates some steps of the usual release workflow:
* Update the manifest version
* Update the manifest.xml hashes
* Add an automated check to ensure that the manifest file is up-to-date (correct hashes and version number)
	* Note that the checks are only run when the release PR is marked as ready for review. This is a workaround explained in https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs
* Automatically update master (fast-forward the merge commit into master) when the release PR is merged

The last manual step is to publish the release, it will automatically create the tag on the last commit of the master branch (the target branch of the release was changed to master).

Includes a fix in tweak_changelogs.sh in the case where we removed the `Release notes generated` comment

### Steps taken to verify a working solution:
- Tested on my fork (TODO links)
